### PR TITLE
Bring in unpackaged charts' source from HomeLab repo

### DIFF
--- a/src/lenin-bot/.helmignore
+++ b/src/lenin-bot/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/src/lenin-bot/Chart.yaml
+++ b/src/lenin-bot/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: lenin-bot
+description: Helm chart for pineapplee discord Lenin bot
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.0.1"

--- a/src/lenin-bot/templates/deployment.yaml
+++ b/src/lenin-bot/templates/deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lenin-discord-bot
+  annotations:
+    field.cattle.io/description: Discord Lenin bot, originally by pineapplee, Dockerfied by me
+  labels:
+    workload.user.cattle.io/workloadselector: apps.deployment-lenin-bot-lenin-discord-bot
+  namespace: lenin-bot
+spec:
+  selector:
+    matchLabels:
+      workload.user.cattle.io/workloadselector: apps.deployment-lenin-bot-lenin-discord-bot
+  template:
+    metadata:
+      labels:
+        workload.user.cattle.io/workloadselector: apps.deployment-lenin-bot-lenin-discord-bot
+    spec:
+      containers:
+        - envFrom:
+            - secretRef:
+                name: lenin-discord-token
+                optional: false
+          image: "skylerspaeth/lenin-bot:{{ .Values.imageVersion }}"
+          imagePullPolicy: IfNotPresent
+          name: container-0

--- a/src/lenin-bot/templates/secret.yaml
+++ b/src/lenin-bot/templates/secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: lenin-discord-token
+  annotations:
+    field.cattle.io/description: Token for pineapplee discord Lenin bot
+  namespace: lenin-bot
+data:
+  LENIN_TOKEN: >-
+    {{ .Values.leninConfig.encodedToken }}

--- a/src/lenin-bot/values.yaml
+++ b/src/lenin-bot/values.yaml
@@ -1,0 +1,8 @@
+# Default values for music-bot.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+imageVersion: 1.0.1
+
+leninConfig:
+  encodedToken: 'YWJjZAo=' # must be overridden when using chart

--- a/src/music-bot/.helmignore
+++ b/src/music-bot/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/src/music-bot/Chart.yaml
+++ b/src/music-bot/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: music-bot
+description: Helm chart for jagrosh discord music bot
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.2
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "2.0.2"

--- a/src/music-bot/templates/configmap.yaml
+++ b/src/music-bot/templates/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: jagrosh-config
+  annotations:
+    field.cattle.io/description: Configuration for jagrosh discord music bot
+  namespace: music-bot
+data:
+  JMB_GAME: "{{ .Values.jagroshConfig.gameStatus }}" # quoted to allow special chars
+  JMB_OWNER: "{{ .Values.jagroshConfig.ownerId }}" # quoted to force str type
+  JMB_PREFIX: "{{ .Values.jagroshConfig.prefix }}" # quoted to allow prefixes starting with !

--- a/src/music-bot/templates/deployment.yaml
+++ b/src/music-bot/templates/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jagrosh-music-bot
+  annotations:
+    field.cattle.io/description: Discord music bot, originally by Jagrosh, Dockerfied by me
+  labels:
+    workload.user.cattle.io/workloadselector: apps.deployment-music-bot-jagrosh-music-bot
+  namespace: music-bot
+spec:
+  selector:
+    matchLabels:
+      workload.user.cattle.io/workloadselector: apps.deployment-music-bot-jagrosh-music-bot
+  template:
+    metadata:
+      labels:
+        workload.user.cattle.io/workloadselector: apps.deployment-music-bot-jagrosh-music-bot
+    spec:
+      containers:
+        - envFrom:
+            - configMapRef:
+                name: jagrosh-config
+                optional: false
+            - secretRef:
+                name: jagrosh-discord-token
+                optional: false
+          image: "skylerspaeth/music-bot:{{ .Values.imageVersion }}"
+          imagePullPolicy: IfNotPresent
+          name: container-0

--- a/src/music-bot/templates/secret.yaml
+++ b/src/music-bot/templates/secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: jagrosh-discord-token
+  annotations:
+    field.cattle.io/description: Token for jagrosh discord music bot
+  namespace: music-bot
+data:
+  JMB_TOKEN: >-
+    {{ .Values.jagroshConfig.encodedToken }}

--- a/src/music-bot/values.yaml
+++ b/src/music-bot/values.yaml
@@ -1,0 +1,12 @@
+# Default values for music-bot.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+imageVersion: 2.0.2
+
+jagroshConfig:
+  encodedToken: 'YWJjZAo=' # must be overridden when using chart
+  gameStatus: 'Now Running In K8s!'
+  ownerId: '000000000000000000' # your discord user id
+  prefix: |
+    !cat


### PR DESCRIPTION
This PR adds the unpackaged charts from the /charts directory of my [HomeLab repo](https://github.com/skylerspaeth/HomeLab).

Corresponds with this PR to delete them from HomeLab repo: https://github.com/skylerspaeth/HomeLab/pull/15