### PR TITLE
Add baseline for functional CS:GO server chart

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,7 @@
+## Creating a new chart
+
+To create a new chart, run the following command:
+
+```bash
+helm create <NAME>
+```

--- a/src/csgo-server/.helmignore
+++ b/src/csgo-server/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/src/csgo-server/Chart.yaml
+++ b/src/csgo-server/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: csgo-server
+description: A Helm chart for deploying a CS:GO server
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.1.0"

--- a/src/csgo-server/templates/_helpers.tpl
+++ b/src/csgo-server/templates/_helpers.tpl
@@ -1,0 +1,26 @@
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "csgo-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "csgo-server.labels" -}}
+helm.sh/chart: {{ include "csgo-server.chart" . }}
+{{ include "csgo-server.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "csgo-server.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/src/csgo-server/templates/deployment.yaml
+++ b/src/csgo-server/templates/deployment.yaml
@@ -1,0 +1,85 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "csgo-server.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "csgo-server.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "csgo-server.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            # - secretRef:
+            #     name: csgo-dedicated-server-token
+            #     optional: false
+            - secretRef:
+                name: csgo-workshop-api-key
+                optional: false
+            - secretRef:
+                name: csgo-rcon-password
+                optional: false
+          env:
+            - name: CSGO_MAP
+              value: "{{ .Values.csgo.defaultMap }}"
+            - name: CSGO_PORT
+              value: "{{ .Values.service.port }}"
+            - name: SOURCEMOD_PLUGINS_ENABLED
+              value: "nolobbyreservation"
+            - name: CSGO_PARAMS
+              value: "-insecure"
+          ports:
+            - name: srcds
+              containerPort: {{ .Values.service.port }}
+              protocol: UDP
+            - name: srcds-rcon
+              containerPort: {{ .Values.rconService.port }}
+              protocol: TCP
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/src/csgo-server/templates/pvc.yaml
+++ b/src/csgo-server/templates/pvc.yaml
@@ -1,0 +1,15 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: csgo-server-datadir
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "csgo-server.labels" . | nindent 4 }}
+spec:
+  accessModes: [ "ReadWriteOnce" ]
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+  {{- if .Values.persistence.customStorageClass }}
+  storageClassName: {{ .Values.persistence.customStorageClass | quote }}
+  {{- end }}

--- a/src/csgo-server/templates/secrets.yaml
+++ b/src/csgo-server/templates/secrets.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: csgo-dedicated-server-token
+  annotations:
+    field.cattle.io/description: Steam dedicated server token for CS:GO
+data:
+  CSGO_GSLT: >-
+    {{ .Values.csgo.gameServerLoginToken | b64enc }}
+
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: csgo-workshop-api-key
+  annotations:
+    field.cattle.io/description: Steam web API key for downloading workshop maps
+data:
+  CSGO_WS_API_KEY: >-
+    {{ .Values.csgo.workshopApiKey | b64enc }}
+
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: csgo-rcon-password
+  annotations:
+    field.cattle.io/description: RCON password for CS:GO server
+data:
+  CSGO_RCON_PW: >-
+    {{ .Values.csgo.rconPassword | b64enc }}

--- a/src/csgo-server/templates/services.yaml
+++ b/src/csgo-server/templates/services.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Chart.Name }}-service
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "csgo-server.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: srcds
+      protocol: UDP
+      {{- if eq .Values.service.type "NodePort" }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
+      name: srcds
+  selector:
+    {{- include "csgo-server.selectorLabels" . | nindent 4 }}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Chart.Name }}-rcon-service
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "csgo-server.labels" . | nindent 4 }}
+  {{- with .Values.rconService.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.rconService.type }}
+  ports:
+    - port: {{ .Values.rconService.port }}
+      targetPort: srcds-rcon
+      protocol: TCP
+      {{- if eq .Values.rconService.type "NodePort" }}
+      nodePort: {{ .Values.rconService.nodePort }}
+      {{- end }}
+      name: srcds
+  selector:
+    {{- include "csgo-server.selectorLabels" . | nindent 4 }}

--- a/src/csgo-server/values.yaml
+++ b/src/csgo-server/values.yaml
@@ -1,0 +1,65 @@
+csgo:
+  gameServerLoginToken: ""
+  workshopApiKey: ""
+  rconPassword: "changeme"
+  defaultMap: "de_nuke"
+
+image:
+  repository: timche/csgo
+  pullPolicy: IfNotPresent
+  tag: sourcemod-4.0.32
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: NodePort
+  port: 27015
+  nodePort: 30555
+  annotations: {}
+
+rconService:
+  type: ClusterIP
+  port: 27015
+  # nodePort: 30123 # include if using NodePort service type
+  annotations: {}
+
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+persistence:
+  # customStorageClass: "" # Uncomment if storage class that's not default is desired
+  size: 64Gi
+
+# Volumes on the output Deployment definition.
+volumes:
+  - name: datadir
+    persistentVolumeClaim:
+      claimName: csgo-server-datadir
+
+# VolumeMounts on the output Deployment definition.
+volumeMounts:
+  - name: datadir
+    mountPath: /home/csgo/server
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
Add a seemingly functional CS:GO server chart. I say seemingly because I'm encountering Tailscale networking issues for having clients outside the server's network connect, but I can connect just fine from within the same network. I don't think this is the fault of the chart though, rather complexities between Tailscale and Source networking, so I'm merging now.